### PR TITLE
Fix Gelatin and Gumobtanium Hunger/Saturation values

### DIFF
--- a/src/main/java/com/unascribed/gumobtainium/item/ItemGelatin.java
+++ b/src/main/java/com/unascribed/gumobtainium/item/ItemGelatin.java
@@ -5,7 +5,7 @@ import net.minecraft.item.ItemFood;
 public class ItemGelatin extends ItemFood {
 
 	public ItemGelatin() {
-		super(9, 10f, false);
+		super(9, 10f/9, false);
 	}
 	
 }

--- a/src/main/java/com/unascribed/gumobtainium/item/ItemGumobtanium.java
+++ b/src/main/java/com/unascribed/gumobtainium/item/ItemGumobtanium.java
@@ -28,7 +28,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public class ItemGumobtanium extends ItemFood {
 
 	public ItemGumobtanium() {
-		super(0, 20, false);
+		super(1, 20, false);
 		setAlwaysEdible();
 	}
 	


### PR DESCRIPTION
Saturation is a multiplier on Hunger, not a separate value. As such, Gelatin is giving 90 saturation, which I assume should actually be 10, while Gumobtanium is giving no hunger or saturation (0 * 20 = 0), while it should be filling up the saturation bar. I simply divided the Gelatin saturation by 9 and gave Gumobtanium the smallest Hunger value that would allow it to fill your Saturation.