### PR TITLE
Mantle fix

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -33,6 +33,7 @@ repositories {
 }
 
 dependencies {
+	deobfCompile "slimeknights.mantle:Mantle:1.12-1.3.3.49"
 	compile 'mezz.jei:jei_1.12.2:4.9.1.189'
 }
 }

--- a/project.gradle
+++ b/project.gradle
@@ -7,7 +7,7 @@ ext {
 	useElytraVersionFormat = true
 	version = '1'
 
-	concreteVersion = '0.4.43'
+	concreteVersion = '0.4.45'
 	concreteModules = [ 'common', 'reflect', 'network' ]
 
 	coremod = null

--- a/src/main/java/com/unascribed/gumobtainium/proxy/ClientProxy.java
+++ b/src/main/java/com/unascribed/gumobtainium/proxy/ClientProxy.java
@@ -45,8 +45,8 @@ public class ClientProxy implements Proxy {
 		ModelLoader.setCustomModelResourceLocation(Gumobtainium.VINEGAR, 0, new ModelResourceLocation(Gumobtainium.MODID+":vinegar#inventory"));
 	}
 	
-	@SubscribeEvent
-	public void onRenderOverlayPost(RenderGameOverlayEvent.Post e) {
+	@SubscribeEvent(priority=EventPriority.LOWEST, receiveCanceled = true)
+	public void onRenderOverlayPre(RenderGameOverlayEvent.Pre e) {
 		Minecraft mc = Minecraft.getMinecraft();
 		if (e.getType() == ElementType.HEALTH) {
 			if (GumData.getGumHearts(mc.player) > 0) {
@@ -65,7 +65,13 @@ public class ClientProxy implements Proxy {
 				}
 				mc.renderEngine.bindTexture(GuiIngameForge.ICONS);
 			}
-		} else if (e.getType() == ElementType.FOOD) {
+		}
+	}
+
+	@SubscribeEvent(priority=EventPriority.LOWEST, receiveCanceled = true)
+	public void onRenderOverlayPost(RenderGameOverlayEvent.Post e) {
+		Minecraft mc = Minecraft.getMinecraft();
+		if (e.getType() == ElementType.FOOD) {
 			if (GumData.hasGumbium(mc.player)) {
 				mc.renderEngine.bindTexture(GUI);
 				GlStateManager.enableAlpha();


### PR DESCRIPTION
Allows Gumobtainium overlays to be rendered even if Mantle is installed. Functions as expected with absorption hearts, additional hearts from additional health with Mantle, etc. 

This was achieved by moving the HEALTH handler into the Pre event and accepting canceled events, as a canceled Pre event never triggers a Post event. 

HUNGER is left in the Post event, but is set to accept canceled events just in case.

Both are set to "LOWEST" as Mantle is currently set to "LOW" priority. This priority could potentially be adjusted or removed, unless Mantle does something to wipe the render area.

To be honest, I can never remember which render thing does what so...